### PR TITLE
CI: Integrate add_build_workflow for codelab-exoplayer-intro from cartland's fork

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -1,0 +1,31 @@
+# Workflow name
+name: Build CodelabExoplayerIntroApp
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build CodelabExoplayerIntroApp app
+        run: ./gradlew :app:assembleDebug


### PR DESCRIPTION
This PR adds GitHub Actions workflow files within .github/workflows/.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.
We are adding "build" workflows with GitHub Actions.
GitHub Actions should usually be configured with the following 3 triggers: `workflow_dispatch`, `push`, `pull_request`.

* `workflow_dispatch`: This trigger allows the workflow to be manually run in the GitHub UI. Most workflows should contain this trigger.
* `push`: Most build and test scripts should run after a change is merged. This should at least run on the default branch, like main, but it could be configured to run on more branches.
* `pull_request`: Most build and test scripts should run on pull requests, at least to the main branch.

Project Owner: Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.

If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.