### PR TITLE
Update build workflow to JDK 17

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
 
       - name: Setup Gradle


### PR DESCRIPTION
This commit updates the Java version used in the build workflow from 11 to 17.