### PR TITLE
Update Media3 version to 1.8.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.example.exoplayercodelab"
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -28,6 +28,6 @@ android {
 
 dependencies {
     // Switch out the code lab step to jump to different points in the codelab
-    implementation project(':exoplayer-codelab-00')
+    implementation project(':exoplayer-codelab-04')
     implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,6 @@ android {
 
 dependencies {
     // Switch out the code lab step to jump to different points in the codelab
-    implementation project(':exoplayer-codelab-04')
+    implementation project(':exoplayer-codelab-00')
     implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     project.ext {
-        compileSdkVersion = 34
+        compileSdkVersion = 36
         minSdkVersion = 21
-        targetSdkVersion = 34
+        targetSdkVersion = 36
         buildToolsVersion = "34.0.0"
 
         kotlin_version = "1.8.0"
@@ -13,7 +13,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/exoplayer-codelab-01/build.gradle
+++ b/exoplayer-codelab-01/build.gradle
@@ -3,7 +3,7 @@ android {
     namespace 'com.example.exoplayer'
 }
 
-def mediaVersion = "1.3.1"
+def mediaVersion = "1.8.0"
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.media3:media3-exoplayer:$mediaVersion"

--- a/exoplayer-codelab-02/build.gradle
+++ b/exoplayer-codelab-02/build.gradle
@@ -3,7 +3,7 @@ android {
     namespace 'com.example.exoplayer'
 }
 
-def mediaVersion = "1.3.1"
+def mediaVersion = "1.8.0"
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.media3:media3-exoplayer:$mediaVersion"

--- a/exoplayer-codelab-03/build.gradle
+++ b/exoplayer-codelab-03/build.gradle
@@ -3,7 +3,7 @@ android {
     namespace 'com.example.exoplayer'
 }
 
-def mediaVersion = "1.3.1"
+def mediaVersion = "1.8.0"
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.media3:media3-exoplayer:$mediaVersion"

--- a/exoplayer-codelab-04/build.gradle
+++ b/exoplayer-codelab-04/build.gradle
@@ -3,7 +3,7 @@ android {
     namespace 'com.example.exoplayer'
 }
 
-def mediaVersion = "1.3.1"
+def mediaVersion = "1.8.0"
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation "androidx.media3:media3-exoplayer:$mediaVersion"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- This change updates the **Media3** library version from `1.3.1` to `1.8.0`.
- It also changes the `compileSdk` from `34` to `36` as required for the library version update.
- I have also updated the library version mentioned in the [codelab Google doc](https://docs.google.com/document/d/1Rpl65ReUWasE7gNpO72AKRslqYu18cBvlRZ9rmhvBcw/edit?tab=t.0).
- This is part of the recommended fixes in the [Friction log](https://docs.google.com/document/d/13uHMDnj34dTx-fL2wKYf-OIwDSCSJXzaD_d951Gm1zg/edit?pli=1&resourcekey=0-DOHjAnKfsfH9rx5_03ZXDA&tab=t.m4a7o9wmbyo6).